### PR TITLE
Add Github Action tests for OpenFaaS functions [CN-55]

### DIFF
--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -4,7 +4,6 @@ on:
   push:
     paths:
       - "hz-client-java/**"
-      - "functions/java-handler.java"
   
 
 jobs:
@@ -19,13 +18,11 @@ jobs:
         run: |
            curl -sSL https://cli.openfaas.com | sudo -E sh
 
-
       - name: Install Hey
         run: |
           wget https://hey-release.s3.us-east-2.amazonaws.com/hey_linux_amd64
           chmod +x hey_linux_amd64
           sudo mv hey_linux_amd64 /bin/hey
-
 
       - name: Checkout to guide
         uses: actions/checkout@v2
@@ -60,14 +57,12 @@ jobs:
 
           echo -n $PASSWORD | faas-cli login --username admin --password-stdin
 
-
       - name: Deploy Hazelcast Cluster
         run: |
           helm repo add hazelcast https://hazelcast-charts.s3.amazonaws.com/
           helm repo update
           helm install hz-hazelcast hazelcast/hazelcast
-          
-
+        
       - name: Create Function
         working-directory: openfaas-hz-guide/hz-client-java/of-watchdog
         run: |
@@ -81,7 +76,6 @@ jobs:
         env:
           DOCKERHUB_PASSWORD: ${{secrets.DOCKERHUB_PASSWORD}}
           DOCKERHUB_USERNAME: ${{secrets.DOCKERHUB_USERNAME}}
-
 
       - name: Test Function
         working-directory: openfaas-hz-guide/hz-client-java/of-watchdog

--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Test Function
         working-directory: openfaas-hz-guide/hz-client-java/of-watchdog
         run: |
-          kubectl get all -n openfaas
+          kubectl get all -n openfaas-fn
 
           kubectl rollout status -n openfaas-fn deployment.apps/hz-client-java-ofwatchdog 
 

--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -1,0 +1,122 @@
+name: Test Java Client
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "hz-client-java/**"
+      - "functions/java-handler.java"
+  
+
+jobs:
+  test-java:
+    name: Test Java Client
+    defaults:
+      run:
+        shell: bash
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install OpenFaaS CLI
+        run: |
+           curl -sSL https://cli.openfaas.com | sudo -E sh
+
+
+      - name: Install Hey
+        run: |
+          wget https://hey-release.s3.us-east-2.amazonaws.com/hey_linux_amd64
+          chmod +x hey_linux_amd64
+          sudo mv hey_linux_amd64 /bin/hey
+
+
+      - name: Checkout to guide
+        uses: actions/checkout@v2
+        with:
+          path: openfaas-hz-guide
+
+      - name: Start Minikube
+        run: |
+          minikube start
+
+      - name: Deploy OpenFaaS
+        run: |
+          kubectl apply -f https://raw.githubusercontent.com/openfaas/faas-netes/master/namespaces.yml
+          
+          helm repo add openfaas https://openfaas.github.io/faas-netes/
+
+          helm repo update \
+          && helm upgrade openfaas --install openfaas/openfaas \
+          --namespace openfaas  \
+          --set functionNamespace=openfaas-fn \
+          --set generateBasicAuth=true
+
+      - name: Log-in to OpenFaaS
+        run: |
+          kubectl rollout status -n openfaas deploy/gateway
+
+          export OPENFAAS_URL=$(minikube service gateway-external -n openfaas --url=true)
+          echo OPENFAAS_URL=${OPENFAAS_URL} >> $GITHUB_ENV
+
+          export PASSWORD=$(kubectl get secret -n openfaas basic-auth -o jsonpath="{.data.basic-auth-password}" | base64 --decode; echo)
+          echo PASSWORD=${PASSWORD} >> $GITHUB_ENV
+
+          echo -n $PASSWORD | faas-cli login --username admin --password-stdin
+
+
+      - name: Deploy Hazelcast Cluster
+        run: |
+          helm repo add hazelcast https://hazelcast-charts.s3.amazonaws.com/
+          helm repo update
+          helm install hz-hazelcast hazelcast/hazelcast
+          
+
+      - name: Create Function
+        working-directory: openfaas-hz-guide/hz-client-java/of-watchdog
+        run: |
+          docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
+          echo -n $PASSWORD | faas-cli login --username admin --password-stdin
+
+          sed -i "s|gateway: .*|gateway: ${OPENFAAS_URL}|" hz-client-java-ofwatchdog.yml
+          sed -i "s/YOUR_DOCKER_HUB_USERNAME/${DOCKERHUB_USERNAME}/" hz-client-java-ofwatchdog.yml
+
+          faas-cli up -f hz-client-java-ofwatchdog.yml
+        env:
+          DOCKERHUB_PASSWORD: ${{secrets.DOCKERHUB_PASSWORD}}
+          DOCKERHUB_USERNAME: ${{secrets.DOCKERHUB_USERNAME}}
+
+
+      - name: Test Function
+        working-directory: openfaas-hz-guide/hz-client-java/of-watchdog
+        run: |
+          kubectl get all -n openfaas
+
+          kubectl rollout status -n openfaas-fn deployment.apps/hz-client-java-ofwatchdog 
+
+          echo -n $PASSWORD | faas-cli login --username admin --password-stdin
+
+          hey -n 100 -c 1 ${OPENFAAS_URL}/function/hz-client-java-ofwatchdog
+
+          size=$(curl ${OPENFAAS_URL}/function/hz-client-java-ofwatchdog)
+
+          echo $size
+
+          if [[ $size -le 101 ]] && [[ $size -ge 100 ]];
+          then
+            exit 0
+          else
+            exit 1
+          fi
+
+
+  slack_notify:
+    name: Slack Notify
+    needs: test-java 
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - uses: 8398a7/action-slack@f3635935f58910a6d6951b73efe9037c960c8c04
+        if: needs.test-java.result != 'success'
+        with:
+          fields: repo,commit,author,action,eventName,workflow
+          status: ${{ needs.test-java.result }}
+          channel: '#github-actions-log'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Test Function
         working-directory: openfaas-hz-guide/hz-client-node/of-watchdog
         run: |
-          kubectl get all -n openfaas
+          kubectl get all -n openfaas-fn
 
           kubectl rollout status -n openfaas-fn deployment.apps/hz-client-node-ofwatchdog 
 
@@ -88,8 +88,8 @@ jobs:
 
           hey -n 100 -c 1 ${OPENFAAS_URL}/function/hz-client-node-ofwatchdog
 
-          size=$(curl ${OPENFAAS_URL}/function/hz-client-node-ofwatchdog)
-
+          curl ${OPENFAAS_URL}/function/hz-client-node-ofwatchdog >> size.json
+          size=$(cat size.json | jq -r '.body')
           echo $size
 
           if [[ $size -le 101 ]] && [[ $size -ge 100 ]];

--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -1,0 +1,120 @@
+name: Test Nodejs Client
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "hz-client-node/**"
+      - "functions/node-handler.js"
+  
+
+jobs:
+  test-node:
+    name: Test NodeJs Client
+    defaults:
+      run:
+        shell: bash
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install OpenFaaS CLI
+        run: |
+           curl -sSL https://cli.openfaas.com | sudo -E sh
+
+
+      - name: Install Hey
+        run: |
+          wget https://hey-release.s3.us-east-2.amazonaws.com/hey_linux_amd64
+          chmod +x hey_linux_amd64
+          sudo mv hey_linux_amd64 /bin/hey
+
+      - name: Checkout to guide
+        uses: actions/checkout@v2
+        with:
+          path: openfaas-hz-guide
+
+      - name: Start Minikube
+        run: |
+          minikube start
+
+      - name: Deploy OpenFaaS
+        run: |
+          kubectl apply -f https://raw.githubusercontent.com/openfaas/faas-netes/master/namespaces.yml
+          
+          helm repo add openfaas https://openfaas.github.io/faas-netes/
+
+          helm repo update \
+          && helm upgrade openfaas --install openfaas/openfaas \
+          --namespace openfaas  \
+          --set functionNamespace=openfaas-fn \
+          --set generateBasicAuth=true
+
+      - name: Log-in to OpenFaaS
+        run: |
+          kubectl rollout status -n openfaas deploy/gateway
+
+          export OPENFAAS_URL=$(minikube service gateway-external -n openfaas --url=true)
+          echo OPENFAAS_URL=${OPENFAAS_URL} >> $GITHUB_ENV
+
+          export PASSWORD=$(kubectl get secret -n openfaas basic-auth -o jsonpath="{.data.basic-auth-password}" | base64 --decode; echo)
+          echo PASSWORD=${PASSWORD} >> $GITHUB_ENV
+
+          echo -n $PASSWORD | faas-cli login --username admin --password-stdin
+
+
+      - name: Deploy Hazelcast Cluster
+        run: |
+          helm repo add hazelcast https://hazelcast-charts.s3.amazonaws.com/
+          helm repo update
+          helm install hz-hazelcast hazelcast/hazelcast
+          
+
+      - name: Create Function
+        working-directory: openfaas-hz-guide/hz-client-node/of-watchdog
+        run: |
+          docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
+          echo -n $PASSWORD | faas-cli login --username admin --password-stdin
+
+          sed -i "s|gateway: .*|gateway: ${OPENFAAS_URL}|" hz-client-node-ofwatchdog.yml
+          sed -i "s/YOUR_DOCKER_HUB_USERNAME/${DOCKERHUB_USERNAME}/" hz-client-node-ofwatchdog.yml
+
+          faas-cli up -f hz-client-node-ofwatchdog.yml
+        env:
+          DOCKERHUB_PASSWORD: ${{secrets.DOCKERHUB_PASSWORD}}
+          DOCKERHUB_USERNAME: ${{secrets.DOCKERHUB_USERNAME}}
+
+      - name: Test Function
+        working-directory: openfaas-hz-guide/hz-client-node/of-watchdog
+        run: |
+          kubectl get all -n openfaas
+
+          kubectl rollout status -n openfaas-fn deployment.apps/hz-client-node-ofwatchdog 
+
+          echo -n $PASSWORD | faas-cli login --username admin --password-stdin
+
+          hey -n 100 -c 1 ${OPENFAAS_URL}/function/hz-client-node-ofwatchdog
+
+          size=$(curl ${OPENFAAS_URL}/function/hz-client-node-ofwatchdog)
+
+          echo $size
+
+          if [[ $size -le 101 ]] && [[ $size -ge 100 ]];
+          then
+            exit 0
+          else
+            exit 1
+          fi
+
+
+  slack_notify:
+    name: Slack Notify
+    needs: test-node 
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - uses: 8398a7/action-slack@f3635935f58910a6d6951b73efe9037c960c8c04
+        if: needs.test-node.result != 'success'
+        with:
+          fields: repo,commit,author,action,eventName,workflow
+          status: ${{ needs.test-node.result }}
+          channel: '#github-actions-log'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -88,7 +88,7 @@ jobs:
 
           hey -n 100 -c 1 ${OPENFAAS_URL}/function/hz-client-node-ofwatchdog
 
-          size=$(curl ${OPENFAAS_URL}/function/hz-client-node-ofwatchdog)
+          size=$( echo $(curl ${OPENFAAS_URL}/function/hz-client-node-ofwatchdog) | jq -r '.body')
 
           echo $size
 

--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -4,7 +4,6 @@ on:
   push:
     paths:
       - "hz-client-node/**"
-      - "functions/node-handler.js"
   
 
 jobs:
@@ -18,7 +17,6 @@ jobs:
       - name: Install OpenFaaS CLI
         run: |
            curl -sSL https://cli.openfaas.com | sudo -E sh
-
 
       - name: Install Hey
         run: |
@@ -59,14 +57,12 @@ jobs:
 
           echo -n $PASSWORD | faas-cli login --username admin --password-stdin
 
-
       - name: Deploy Hazelcast Cluster
         run: |
           helm repo add hazelcast https://hazelcast-charts.s3.amazonaws.com/
           helm repo update
           helm install hz-hazelcast hazelcast/hazelcast
           
-
       - name: Create Function
         working-directory: openfaas-hz-guide/hz-client-node/of-watchdog
         run: |

--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -88,7 +88,7 @@ jobs:
 
           hey -n 100 -c 1 ${OPENFAAS_URL}/function/hz-client-node-ofwatchdog
 
-          size=$( echo $(curl ${OPENFAAS_URL}/function/hz-client-node-ofwatchdog) | jq -r '.body')
+          size=$(curl ${OPENFAAS_URL}/function/hz-client-node-ofwatchdog)
 
           echo $size
 

--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -89,7 +89,7 @@ jobs:
           hey -n 100 -c 1 ${OPENFAAS_URL}/function/hz-client-node-ofwatchdog
 
           curl ${OPENFAAS_URL}/function/hz-client-node-ofwatchdog >> size.json
-          size=$(cat size.json | jq -r '.body')
+          size=$(cat size.json | jq -r '.size')
           echo $size
 
           if [[ $size -le 101 ]] && [[ $size -ge 100 ]];

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -4,7 +4,6 @@ on:
   push:
     paths:
       - "hz-client-python/**"
-      - "functions/python-handler.py"
 
 
 jobs:
@@ -18,7 +17,6 @@ jobs:
       - name: Install OpenFaaS CLI
         run: |
            curl -sSL https://cli.openfaas.com | sudo -E sh
-
 
       - name: Install Hey
         run: |
@@ -59,14 +57,12 @@ jobs:
 
           echo -n $PASSWORD | faas-cli login --username admin --password-stdin
 
-
       - name: Deploy Hazelcast Cluster
         run: |
           helm repo add hazelcast https://hazelcast-charts.s3.amazonaws.com/
           helm repo update
           helm install hz-hazelcast hazelcast/hazelcast
           
-
       - name: Create Function
         working-directory: openfaas-hz-guide/hz-client-python/of-watchdog
         run: |

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -1,0 +1,122 @@
+name: Test Python Client
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "hz-client-python/**"
+      - "functions/python-handler.py"
+
+
+jobs:
+  test-python:
+    name: Test Python Client
+    defaults:
+      run:
+        shell: bash
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install OpenFaaS CLI
+        run: |
+           curl -sSL https://cli.openfaas.com | sudo -E sh
+
+
+      - name: Install Hey
+        run: |
+          wget https://hey-release.s3.us-east-2.amazonaws.com/hey_linux_amd64
+          chmod +x hey_linux_amd64
+          sudo mv hey_linux_amd64 /bin/hey
+
+      - name: Checkout to guide
+        uses: actions/checkout@v2
+        with:
+          path: openfaas-hz-guide
+
+      - name: Start Minikube
+        run: |
+          minikube start
+
+      - name: Deploy OpenFaaS
+        run: |
+          kubectl apply -f https://raw.githubusercontent.com/openfaas/faas-netes/master/namespaces.yml
+          
+          helm repo add openfaas https://openfaas.github.io/faas-netes/
+
+          helm repo update \
+          && helm upgrade openfaas --install openfaas/openfaas \
+          --namespace openfaas  \
+          --set functionNamespace=openfaas-fn \
+          --set generateBasicAuth=true
+
+      - name: Log-in to OpenFaaS
+        run: |
+          kubectl rollout status -n openfaas deploy/gateway
+
+          export OPENFAAS_URL=$(minikube service gateway-external -n openfaas --url=true)
+          echo OPENFAAS_URL=${OPENFAAS_URL} >> $GITHUB_ENV
+
+          export PASSWORD=$(kubectl get secret -n openfaas basic-auth -o jsonpath="{.data.basic-auth-password}" | base64 --decode; echo)
+          echo PASSWORD=${PASSWORD} >> $GITHUB_ENV
+
+          echo -n $PASSWORD | faas-cli login --username admin --password-stdin
+
+
+      - name: Deploy Hazelcast Cluster
+        run: |
+          helm repo add hazelcast https://hazelcast-charts.s3.amazonaws.com/
+          helm repo update
+          helm install hz-hazelcast hazelcast/hazelcast
+          
+
+      - name: Create Function
+        working-directory: openfaas-hz-guide/hz-client-python/of-watchdog
+        run: |
+          faas template pull https://github.com/openfaas-incubator/python-flask-template
+          
+          docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
+          echo -n $PASSWORD | faas-cli login --username admin --password-stdin
+
+          sed -i "s|gateway: .*|gateway: ${OPENFAAS_URL}|" hz-client-python-ofwatchdog.yml
+          sed -i "s/YOUR_DOCKER_HUB_USERNAME/${DOCKERHUB_USERNAME}/" hz-client-python-ofwatchdog.yml
+
+          faas-cli up -f hz-client-python-ofwatchdog.yml --build-arg "TEST_ENABLED=false"
+        env:
+          DOCKERHUB_PASSWORD: ${{secrets.DOCKERHUB_PASSWORD}}
+          DOCKERHUB_USERNAME: ${{secrets.DOCKERHUB_USERNAME}}
+
+      - name: Test Function
+        working-directory: openfaas-hz-guide/hz-client-python/of-watchdog
+        run: |
+          kubectl get all -n openfaas
+
+          kubectl rollout status -n openfaas-fn deployment.apps/hz-client-python-ofwatchdog 
+
+          echo -n $PASSWORD | faas-cli login --username admin --password-stdin
+
+          hey -n 100 -c 1 ${OPENFAAS_URL}/function/hz-client-python-ofwatchdog
+
+          size=$(curl ${OPENFAAS_URL}/function/hz-client-python-ofwatchdog)
+
+          echo $size
+
+          if [[ $size -le 101 ]] && [[ $size -ge 100 ]];
+          then
+            exit 0
+          else
+            exit 1
+          fi
+
+
+  slack_notify:
+    name: Slack Notify
+    needs: test-python 
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - uses: 8398a7/action-slack@f3635935f58910a6d6951b73efe9037c960c8c04
+        if: needs.test-python.result != 'success'
+        with:
+          fields: repo,commit,author,action,eventName,workflow
+          status: ${{ needs.test-python.result }}
+          channel: '#github-actions-log'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Test Function
         working-directory: openfaas-hz-guide/hz-client-python/of-watchdog
         run: |
-          kubectl get all -n openfaas
+          kubectl get all -n openfaas-fn
 
           kubectl rollout status -n openfaas-fn deployment.apps/hz-client-python-ofwatchdog 
 

--- a/hz-client-java/of-watchdog/hz-client-java-ofwatchdog/src/main/java/com/openfaas/function/Handler.java
+++ b/hz-client-java/of-watchdog/hz-client-java-ofwatchdog/src/main/java/com/openfaas/function/Handler.java
@@ -35,7 +35,7 @@ public class Handler extends com.openfaas.model.AbstractHandler {
     public IResponse Handle(IRequest req) {
         Response res = new Response();
         Random random = new Random();
-        int randomKey = random.nextInt(100_000);
+        int randomKey = random.nextInt(1_000_000);
         this.map.put("key-" + randomKey, "value-" + randomKey);
 	    res.setBody(String.valueOf(this.map.size()));
 	    return res;

--- a/hz-client-node/classic-watchdog/hz-client-node-classic/handler.js
+++ b/hz-client-node/classic-watchdog/hz-client-node-classic/handler.js
@@ -30,10 +30,8 @@ module.exports = async (event, context) => {
   const number = between(1, 1000000);
   await map.put(`${number}`, `value-${number}`);
   const size = await map.size();
-  const result = {
-    'body': `${size}`,
-  }
+
   return context
     .status(200)
-    .succeed(result)
+    .succeed(size)
 }

--- a/hz-client-node/classic-watchdog/hz-client-node-classic/handler.js
+++ b/hz-client-node/classic-watchdog/hz-client-node-classic/handler.js
@@ -33,5 +33,5 @@ module.exports = async (event, context) => {
 
   return context
     .status(200)
-    .succeed(size)
+    .succeed({"size" : size})
 }

--- a/hz-client-node/classic-watchdog/hz-client-node-classic/handler.js
+++ b/hz-client-node/classic-watchdog/hz-client-node-classic/handler.js
@@ -27,7 +27,7 @@ module.exports = async (event, context) => {
     map = await hz.getMap('map');
   }
 
-  const number = between(1, 100000);
+  const number = between(1, 1000000);
   await map.put(`${number}`, `value-${number}`);
   const size = await map.size();
   const result = {

--- a/hz-client-node/of-watchdog/hz-client-node-ofwatchdog/handler.js
+++ b/hz-client-node/of-watchdog/hz-client-node-ofwatchdog/handler.js
@@ -33,5 +33,5 @@ module.exports = async (event, context) => {
   
   return context
     .status(200)
-    .succeed(size)
+    .succeed({"size" : size})
 }

--- a/hz-client-node/of-watchdog/hz-client-node-ofwatchdog/handler.js
+++ b/hz-client-node/of-watchdog/hz-client-node-ofwatchdog/handler.js
@@ -27,7 +27,7 @@ module.exports = async (event, context) => {
     map = await hz.getMap('map');
   }
 
-  const number = between(1, 100000);
+  const number = between(1, 1000000);
   await map.put(`${number}`, `value-${number}`);
   const size = await map.size();
   const result = {

--- a/hz-client-node/of-watchdog/hz-client-node-ofwatchdog/handler.js
+++ b/hz-client-node/of-watchdog/hz-client-node-ofwatchdog/handler.js
@@ -30,10 +30,8 @@ module.exports = async (event, context) => {
   const number = between(1, 1000000);
   await map.put(`${number}`, `value-${number}`);
   const size = await map.size();
-  const result = {
-    'body': `${size}`,
-  }
+  
   return context
     .status(200)
-    .succeed(result)
+    .succeed(size)
 }

--- a/hz-client-python/classic-watchdog/hz-client-python-classic/handler.py
+++ b/hz-client-python/classic-watchdog/hz-client-python-classic/handler.py
@@ -8,13 +8,14 @@ client = hazelcast.HazelcastClient(
 
 my_map = client.get_map("map").blocking()
 
+
 def handle(req):
     """handle a request to the function
     Args:
         req (str): request body
     """
-    ran_val = random.randint(1,100000)
-    
+    ran_val = random.randint(1, 1000000)
+
     my_map.put(f"{ran_val}", "value")
 
     return str(my_map.size())

--- a/hz-client-python/of-watchdog/hz-client-python-ofwatchdog/handler.py
+++ b/hz-client-python/of-watchdog/hz-client-python-ofwatchdog/handler.py
@@ -13,7 +13,7 @@ def handle(req):
     Args:
         req (str): request body
     """
-    ran_val = random.randint(1,100000)
+    ran_val = random.randint(1,1000000)
     
     my_map.put(f"{ran_val}", "value")
 


### PR DESCRIPTION
I added Github Actions tests for all clients in the guide: Java, Nodejs and Python. The workflows do the following
- Install OpenFaaS
- Start Minikube
- Deploy Hazelcast cluster to Minikube
- Build and Deploy Hazelcast client functions on Minikube.
- Send requests to client funtions to update a map of the cluster.
- Check if the requests finished successfully.

TODO
- [x] Add secrets for Docker Hub credentials and Slack webhook.